### PR TITLE
Add support for multiline processing

### DIFF
--- a/test/string_ext.rb
+++ b/test/string_ext.rb
@@ -83,6 +83,11 @@ assert('String#color') do
 
   assert_equal "\e[1;41;31mhello\e[m", 'hello'.red.bg_red.bold, 'red, background red, bold method'
 
+  assert_equal "\e[31mhello\e[m\n\e[31mworld\e[m", "hello\nworld".red, 'multi-line'
+
+  assert_equal '', ''.color(:red), 'empty string'
+  assert_equal "\r\n", "\r\n".color(:red), 'newline characters'
+
   assert_raise(ArgumentError) { 'hello'.color(:unknown) }
   assert_raise(ArgumentError) { 'hello'.color(300) }
   assert_raise(ArgumentError) { 'hello'.color('#fff') }


### PR DESCRIPTION
改行コードを含めたときに各行でエスケープシーケンスを設定するように変更します。

```ruby
# 変更前
"\e[31mhello" + "\n" + "world\e[m"

# 変更後
"\e[31mhello\e[m" + "\n" + "\e[31mworld\e[m"
```