### PR TITLE
Fix typo in macro name

### DIFF
--- a/src/terminal_color.c
+++ b/src/terminal_color.c
@@ -11,7 +11,7 @@
 #include "terminal_color.h"
 
 #define mrb_terminal_color() mrb_module_get_id(mrb, MRB_SYM(TerminalColor))
-#define mrb_termianl_color_const_get(sym) mrb_const_get(mrb, mrb_obj_value(mrb_terminal_color()), sym)
+#define mrb_terminal_color_const_get(sym) mrb_const_get(mrb, mrb_obj_value(mrb_terminal_color()), sym)
 
 mrb_value color_code_4bit(mrb_state *mrb, mrb_value color, mrb_bool bg_color)
 {
@@ -23,7 +23,7 @@ mrb_value color_code_4bit(mrb_state *mrb, mrb_value color, mrb_bool bg_color)
     mrb_value color_name = mrb_symbol_p(color) ? color : mrb_symbol_value(mrb_intern_str(mrb, color));
 
     mrb_sym table_name = bg_color ? MRB_SYM(ANSI_BG_COLOR_CODES) : MRB_SYM(ANSI_COLOR_CODES);
-    mrb_value table = mrb_termianl_color_const_get(table_name);
+    mrb_value table = mrb_terminal_color_const_get(table_name);
     return mrb_hash_get(mrb, table, color_name);
 }
 
@@ -150,7 +150,7 @@ mrb_value mrb_value_to_mode_code(mrb_state *mrb, mrb_value mode, mrb_bool fallba
     if (mrb_symbol_p(mode) || mrb_string_p(mode))
     {
         mrb_sym name = mrb_symbol_p(mode) ? mrb_symbol(mode) : mrb_intern_str(mrb, mode);
-        mrb_value table = mrb_termianl_color_const_get(MRB_SYM(ANSI_MODE_CODES));
+        mrb_value table = mrb_terminal_color_const_get(MRB_SYM(ANSI_MODE_CODES));
         mrb_value mode_code = mrb_hash_get(mrb, table, mrb_symbol_value(name));
         if (!mrb_nil_p(mode_code))
         {


### PR DESCRIPTION
Hi @buty4649
Great library! It is going to be helpful for my application.
I ran typos-cli and found a small typo, so I’ll send a small pull request.
Thanks in advance.